### PR TITLE
Add FastAPI classifier in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Framework :: FastAPI",
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="design-by-contract contracts automatic testing property-based",


### PR DESCRIPTION
This patch makes it clear in `setup.py` that we are related to FastAPI
so that it is easier to find it on PyPI.